### PR TITLE
Save network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ cython_debug/
 
 # Application specific files
 bridge.json
+network.json
+network.pkl

--- a/__main__.py
+++ b/__main__.py
@@ -1,11 +1,9 @@
 import os
-from time import perf_counter
 
 from dotenv import load_dotenv
-from loguru import logger
 
 from philips_hue_v2.bridge import HueBridge
-from philips_hue_v2.resource.network import Network, pickle_network, unpickle_network
+from philips_hue_v2.resource.network import Network, unpickle_network
 from philips_hue_v2.resource.requests import get_resources
 
 
@@ -45,6 +43,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    start = perf_counter()
-    main_load_pickled_network()
-    logger.info(perf_counter() - start)
+    main()

--- a/__main__.py
+++ b/__main__.py
@@ -1,13 +1,27 @@
 import os
+from time import perf_counter
 
 from dotenv import load_dotenv
+from loguru import logger
 
 from philips_hue_v2.bridge import HueBridge
-from philips_hue_v2.resource.network import Network
+from philips_hue_v2.resource.network import Network, pickle_network, unpickle_network
 from philips_hue_v2.resource.requests import get_resources
 
 
 load_dotenv()  # take environment variables from .env.
+
+
+def main_load_pickled_network() -> None:
+    """Main entry point when using a pickled network."""
+    network = unpickle_network()
+    bibblan = network.get_light_by_id("23e8c74f-7c0e-40ae-b61d-f10df2f165be")
+
+    if not bibblan:
+        return
+
+    bibblan.turn_on()
+    bibblan.set_rgb_color({"red": 255, "green": 255, "blue": 255})
 
 
 def main() -> None:
@@ -18,7 +32,9 @@ def main() -> None:
         user_name=os.getenv("USER_NAME", ""),
     )
     resources_response = get_resources(bridge)
-    network = Network(resources=resources_response.unwrap(), bridge=bridge)
+    resources = resources_response.unwrap()
+    network = Network(resources=resources, bridge=bridge)
+
     bibblan = network.get_light_by_id("23e8c74f-7c0e-40ae-b61d-f10df2f165be")
 
     if not bibblan:
@@ -29,4 +45,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    start = perf_counter()
+    main_load_pickled_network()
+    logger.info(perf_counter() - start)

--- a/philips_hue_v2/resource/network.py
+++ b/philips_hue_v2/resource/network.py
@@ -1,3 +1,5 @@
+import pickle
+from pathlib import Path
 from typing import Any
 
 from ..bridge import HueBridge
@@ -51,3 +53,11 @@ class Network:
     def parse_lights(self, resources: list[dict[str, Any]]) -> list[Lights]:
         """Get a list of all lights among the resources."""
         return [Lights(bridge=self.bridge, **resource) for resource in resources if resource["type"] == "light"]
+
+
+def pickle_network(network: Network, path: Path = Path("network.pkl")) -> None:
+    pickle.dump(network, path.open("wb"))
+
+
+def unpickle_network(path: Path = Path("network.pkl")) -> Network:
+    return pickle.load(path.open("rb"))


### PR DESCRIPTION
Adding the possibility to save the network as a pickled file. The network is usually being changed quite seldom, so it is possible to create a network and then save it to a file. Thus, we don't have to query for the network structure every time we run the script, but we simply load the network from the file.

This does make it faster by roughly 50%. Typically around 1-1,2 seconds without pickling and 0,5-0,6 seconds with pickling.

It does however add a security concern as it is possible to inject harmful code by editing the pickled file...